### PR TITLE
Use dependency injection to pass server filters into service handlers

### DIFF
--- a/src/main/java/org/protege/editor/owl/server/api/AbstractServerFilter.java
+++ b/src/main/java/org/protege/editor/owl/server/api/AbstractServerFilter.java
@@ -19,7 +19,7 @@ public abstract class AbstractServerFilter extends ServerLayer {
     }
 
     @Override
-    protected ServerConfiguration getConfiguration() {
+    public ServerConfiguration getConfiguration() {
         return getDelegate().getConfiguration();
     }
 }

--- a/src/main/java/org/protege/editor/owl/server/api/ServerFilterAdapter.java
+++ b/src/main/java/org/protege/editor/owl/server/api/ServerFilterAdapter.java
@@ -4,7 +4,6 @@ import edu.stanford.protege.metaproject.api.*;
 import org.protege.editor.owl.server.api.exception.AuthorizationException;
 import org.protege.editor.owl.server.api.exception.OutOfSyncException;
 import org.protege.editor.owl.server.api.exception.ServerServiceException;
-import org.protege.editor.owl.server.change.ChangeDocumentPool;
 import org.protege.editor.owl.server.versioning.api.ChangeHistory;
 import org.protege.editor.owl.server.versioning.api.ServerDocument;
 
@@ -19,14 +18,8 @@ import java.util.Optional;
  */
 public class ServerFilterAdapter extends AbstractServerFilter {
 
-    private static ChangeDocumentPool changePool = new ChangeDocumentPool();
-
     public ServerFilterAdapter(ServerLayer delegate) {
         super(delegate);
-    }
-
-    public ChangeDocumentPool getChangePool() {
-        return changePool;
     }
 
     @Override

--- a/src/main/java/org/protege/editor/owl/server/api/ServerLayer.java
+++ b/src/main/java/org/protege/editor/owl/server/api/ServerLayer.java
@@ -15,7 +15,7 @@ public abstract class ServerLayer implements Server {
      *
      * @return Server configuration
      */
-    protected abstract ServerConfiguration getConfiguration();
+    public abstract ServerConfiguration getConfiguration();
 
     public void addServerListener(ServerListener listener) {
         listeners.add(listener);

--- a/src/main/java/org/protege/editor/owl/server/change/ChangeManagementFilter.java
+++ b/src/main/java/org/protege/editor/owl/server/change/ChangeManagementFilter.java
@@ -26,17 +26,20 @@ import java.util.Optional;
  */
 public class ChangeManagementFilter extends ServerFilterAdapter {
 
-    private Logger logger = LoggerFactory.getLogger(ChangeManagementFilter.class);
+    private static final Logger logger = LoggerFactory.getLogger(ChangeManagementFilter.class);
 
-    public ChangeManagementFilter(ServerLayer delegate) {
+    private final ChangeDocumentPool changePool;
+
+    public ChangeManagementFilter(ServerLayer delegate, ChangeDocumentPool changePool) {
         super(delegate);
+        this.changePool = changePool;
     }
 
     @Override
     public ServerDocument createProject(AuthToken token, ProjectId projectId, Name projectName, Description description,
             UserId owner, Optional<ProjectOptions> options) throws AuthorizationException, ServerServiceException {
         ServerDocument serverDocument = super.createProject(token, projectId, projectName, description, owner, options);
-        getChangePool().appendChanges(serverDocument.getHistoryFile(), ChangeHistoryImpl.createEmptyChangeHistory());
+        changePool.appendChanges(serverDocument.getHistoryFile(), ChangeHistoryImpl.createEmptyChangeHistory());
         return serverDocument;
     }
 
@@ -48,7 +51,7 @@ public class ChangeManagementFilter extends ServerFilterAdapter {
             Project project = getConfiguration().getProject(projectId);
             String projectFilePath = project.getFile().getAbsolutePath();
             HistoryFile historyFile = HistoryFile.openExisting(projectFilePath);
-            getChangePool().appendChanges(historyFile, changeHistory);
+            changePool.appendChanges(historyFile, changeHistory);
             return changeHistory;
         }
         catch (UnknownProjectIdException e) {

--- a/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
+++ b/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
@@ -7,15 +7,28 @@ import edu.stanford.protege.metaproject.api.exception.ObjectConversionException;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.UndertowOptions;
+import io.undertow.server.HttpHandler;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.BlockingHandler;
 import io.undertow.server.handlers.GracefulShutdownHandler;
 import io.undertow.util.StatusCodes;
+import org.protege.editor.owl.server.api.ChangeService;
+import org.protege.editor.owl.server.api.ServerLayer;
 import org.protege.editor.owl.server.api.LoginService;
 import org.protege.editor.owl.server.base.ProtegeServer;
+import org.protege.editor.owl.server.change.ChangeDocumentPool;
+import org.protege.editor.owl.server.change.ChangeManagementFilter;
+import org.protege.editor.owl.server.change.DefaultChangeService;
+import org.protege.editor.owl.server.conflict.ConflictDetectionFilter;
 import org.protege.editor.owl.server.http.exception.ServerConfigurationInitializationException;
 import org.protege.editor.owl.server.http.exception.ServerException;
-import org.protege.editor.owl.server.http.handlers.*;
+import org.protege.editor.owl.server.http.handlers.AuthenticationHandler;
+import org.protege.editor.owl.server.http.handlers.CodeGenHandler;
+import org.protege.editor.owl.server.http.handlers.HTTPChangeService;
+import org.protege.editor.owl.server.http.handlers.HTTPLoginService;
+import org.protege.editor.owl.server.http.handlers.HTTPServerHandler;
+import org.protege.editor.owl.server.http.handlers.MetaprojectHandler;
+import org.protege.editor.owl.server.policy.AccessControlFilter;
 import org.protege.editor.owl.server.security.SSLContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,10 +114,18 @@ public final class HTTPServer {
 	}
 
 	public void start() throws Exception {
-		final ProtegeServer pserver = new ProtegeServer(serverConfiguration);
-		final URI serverHostUri = serverConfiguration.getHost().getUri();
-		final int serverAdminPort = serverConfiguration.getHost().getSecondaryPort().get().get();
+		/*
+		 * Instantiate Protege server modules
+		 */
+		ChangeDocumentPool changePool = new ChangeDocumentPool();
+		ChangeService changeService = new DefaultChangeService(changePool);
+		ProtegeServer pserver = new ProtegeServer(serverConfiguration);
+		ServerLayer cmf = new ChangeManagementFilter(pserver, changePool);
+		ServerLayer acf = new AccessControlFilter(new ConflictDetectionFilter(cmf, changeService));
 		
+		/*
+		 * Instantiate and setup HTTP routing handlers
+		 */
 		RoutingHandler webRouter = Handlers.routing();
 		RoutingHandler adminRouter = Handlers.routing();
 		
@@ -115,7 +136,7 @@ public final class HTTPServer {
 		adminRouter.add("POST", LOGIN, login_handler);
 		
 		// create change service handler
-		AuthenticationHandler changeServiceHandler = new AuthenticationHandler(new BlockingHandler(new HTTPChangeService(pserver)));
+		AuthenticationHandler changeServiceHandler = new AuthenticationHandler(new BlockingHandler(new HTTPChangeService(server)));
 		webRouter.add("POST", COMMIT,  changeServiceHandler);
 		webRouter.add("POST", HEAD,  changeServiceHandler);
 		webRouter.add("POST", LATEST_CHANGES,  changeServiceHandler);
@@ -143,12 +164,15 @@ public final class HTTPServer {
 		AuthenticationHandler serverHandler = new AuthenticationHandler(new BlockingHandler(new HTTPServerHandler()));
 		adminRouter.add("POST", SERVER_RESTART, serverHandler);
 		adminRouter.add("POST", SERVER_STOP, serverHandler);
+
 		
 		// Build the servers
 		webRouterHandler = Handlers.gracefulShutdown(Handlers.exceptionHandler(webRouter));
 		adminRouterHandler = Handlers.gracefulShutdown(Handlers.exceptionHandler(adminRouter));
 		
 		logger.info("Starting server instances");
+		final URI serverHostUri = serverConfiguration.getHost().getUri();
+		final int serverAdminPort = serverConfiguration.getHost().getSecondaryPort().get().get();
 		if (serverHostUri.getScheme().equalsIgnoreCase("https")) {
 			SSLContext ctx = new SSLContextFactory().createSslContext();
 			webServer = Undertow.builder()

--- a/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
+++ b/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
@@ -136,20 +136,20 @@ public final class HTTPServer {
 		adminRouter.add("POST", LOGIN, login_handler);
 		
 		// create change service handler
-		AuthenticationHandler changeServiceHandler = new AuthenticationHandler(new BlockingHandler(new HTTPChangeService(server)));
+		HttpHandler changeServiceHandler = new AuthenticationHandler(new BlockingHandler(new HTTPChangeService(acf, changeService)));
 		webRouter.add("POST", COMMIT,  changeServiceHandler);
 		webRouter.add("POST", HEAD,  changeServiceHandler);
 		webRouter.add("POST", LATEST_CHANGES,  changeServiceHandler);
 		webRouter.add("POST", ALL_CHANGES,  changeServiceHandler);
 		
 		// create code generator handler
-		AuthenticationHandler codeGenHandler = new AuthenticationHandler(new BlockingHandler(new CodeGenHandler(pserver)));
+		HttpHandler codeGenHandler = new AuthenticationHandler(new BlockingHandler(new CodeGenHandler(pserver)));
 		webRouter.add("GET", GEN_CODE, codeGenHandler);
 		webRouter.add("GET", GEN_CODES, codeGenHandler);
 		webRouter.add("POST", EVS_REC, codeGenHandler);
 		
 		// create mataproject handler
-		AuthenticationHandler metaprojectHandler = new AuthenticationHandler(new BlockingHandler(new MetaprojectHandler(pserver)));
+		HttpHandler metaprojectHandler = new AuthenticationHandler(new BlockingHandler(new MetaprojectHandler(pserver)));
 		webRouter.add("GET", METAPROJECT, metaprojectHandler);
 		webRouter.add("GET", PROJECT,  metaprojectHandler);
 		webRouter.add("POST", PROJECT_SNAPSHOT_GET,  metaprojectHandler);


### PR DESCRIPTION
@bdionne Let me know if this code refactor breaks your current development. For me, it passed the tests.

Highlights in the code refactor:
 - Remove static ChangeDocumentPool in ServerFilterAdapter.java (line 22)
```
- private static ChangeDocumentPool changePool = new ChangeDocumentPool();		
```
- Inject the ServerFilter into the handlers constructors, instead of instantiating those filters inside the handler's constructor.

For example, instead of having the dependency constructed inside the handler's constructor
```
-	public HTTPChangeService(ProtegeServer s) {		+	public HTTPChangeService(ServerLayer serverLayer, ChangeService changeService) {
-		cf = new ConflictDetectionFilter(new ChangeManagementFilter(s));		+		this.serverLayer = serverLayer;
-		acf = new AccessControlFilter(cf);		+		this.changeService = changeService;
-		changeService = new DefaultChangeService(acf.getChangePool());		
 	}
```
I injected the dependency into the constructor
```
+	public HTTPChangeService(ServerLayer serverLayer, ChangeService changeService) {
+		this.serverLayer = serverLayer;
+		this.changeService = changeService;
 	}
```
